### PR TITLE
Fix tab (file) replication while moving already existing items

### DIFF
--- a/lib/pane-by-type.js
+++ b/lib/pane-by-type.js
@@ -27,9 +27,17 @@ export default class PaneByType {
       const paneWithType = this.getPaneWithType(ext);
 
       if (paneWithType) {
-        paneWithType.activate();
-        pane.moveItemToPane(item, paneWithType);
-        paneWithType.activateItem(item);
+        paneWithType.activate()
+        const existingItem = paneWithType.itemForURI(item.buffer.getUri());
+
+        if (existingItem) {
+          pane.destroyItem(item);
+          paneWithType.activateItem(existingItem);
+        }
+        else {
+          pane.moveItemToPane(item, paneWithType);
+          paneWithType.activateItem(item);
+        }
       }
     }
   }


### PR DESCRIPTION
 (only on Atom 1.4.3, and upwards?)
